### PR TITLE
Support manipulating hierarchical labels

### DIFF
--- a/src/skip/eeschema/label.py
+++ b/src/skip/eeschema/label.py
@@ -69,4 +69,16 @@ class GlobalLabelCollection(BaseLabelCollection):
     def _new_instance(self):
         newObj = GlobalLabelWrapper(self.parent.new_from_list(ElementTemplate['global_label']))
         return newObj
+
+class HierarchicalLabelWrapper(BaseLabelWrapper):
+    def __init__(self,v:ParsedValue):
+        super().__init__(v)
+    
+class HierarchicalLabelCollection(BaseLabelCollection):
+    def __init__(self, parent, elements:list):
+        super().__init__(parent, elements)
+        
+    def _new_instance(self):
+        newObj = HierarchicalLabelWrapper(self.parent.new_from_list(ElementTemplate['hierarchical_label']))
+        return newObj
     

--- a/src/skip/eeschema/schematic/schematic.py
+++ b/src/skip/eeschema/schematic/schematic.py
@@ -16,7 +16,7 @@ from skip.eeschema.sheet.sheet import SheetWrapper
 from skip.eeschema.lib_symbol import LibSymbolsListWrapper
 from skip.eeschema.wire import WireCollection, WireWrapper
 from skip.eeschema.label import LabelCollection, LabelWrapper
-from skip.eeschema.label import GlobalLabelCollection, GlobalLabelWrapper
+from skip.eeschema.label import HierarchicalLabelCollection, GlobalLabelCollection, GlobalLabelWrapper
 from skip.eeschema.text import TextCollection, TextWrapper
 from skip.eeschema.junction import JunctionCollection, JunctionWrapper
 import logging 
@@ -96,6 +96,7 @@ class Schematic(SourceFile):
             'wire': WireCollection,
             'label': LabelCollection,
             'global_label': GlobalLabelCollection,
+            'hierarchical_label': HierarchicalLabelCollection,
             'text': TextCollection,
             'junction': JunctionCollection
         }

--- a/src/skip/element_template.py
+++ b/src/skip/element_template.py
@@ -28,6 +28,14 @@ ElementTemplate = {
               [Symbol('effects'), [Symbol('font'), [Symbol('size'), 1.27, 1.27]], 
                [Symbol('justify'), Symbol('left'), Symbol('bottom')]], 
               [Symbol('uuid'), Symbol('SOMEUUID')]],
+
+    'hierarchical_label': [Symbol('hierarchical_label'), 'HLABEL', 
+                           [Symbol('shape'), Symbol('input')],
+                           [Symbol('at'), 25.4, 25.4, 0], 
+                           [Symbol('fields_autoplaced')], 
+                           [Symbol('effects'), [Symbol('font'), [Symbol('size'), 1.27, 1.27]], 
+                            [Symbol('justify'), Symbol('right')]], 
+                           [Symbol('uuid'), Symbol('SOMEUUID')]],
     
     
     'text': [Symbol('text'), 'hello', [Symbol('at'), 58.42, 48.26, 0], 


### PR DESCRIPTION
Tested using

```python
from skip import Schematic

sch = Schematic('schematic.kicad_sch')

for glabel in sch.global_label:
    hlabel = sch.hierarchical_label.new()
    hlabel.value = glabel.value
    hlabel.move(glabel.at[0], glabel.at[1], glabel.at[2])
    hlabel.effects.justify.value = glabel.effects.justify.value
    glabel.delete()

sch.write('/tmp/schematic.kicad_sch')
```
