### PR TITLE
Enhance the ParsedValue.value setter to handle the case when users add new attributes

### DIFF
--- a/src/skip/sexp/parser.py
+++ b/src/skip/sexp/parser.py
@@ -9,6 +9,7 @@ import sexpdata
 import uuid
 import re
 import copy
+from functools import reduce
 
 import logging 
 log = logging.getLogger(__name__)
@@ -162,7 +163,7 @@ class ParsedValue(AccessesTree):
         return self._value 
         
     @value.setter 
-    def value(self, setTo):
+    def value(self, setTo: str|bool|int|float|list):
         '''
             Set values on the .value attribute.
             
@@ -170,10 +171,20 @@ class ParsedValue(AccessesTree):
             sch.symbol.C4.dnp.value = True 
         
         '''
-        if self._is_bool_symbol(self._value):
-            
-            if not isinstance(setTo, str):
-                
+
+        children_updated = False
+        if isinstance(setTo, list):
+            all_simple = reduce(lambda acc, x: acc and not isinstance(x, list), setTo, True)
+            if all_simple:
+                self._value = setTo
+            else:
+                self._tree[1:] = setTo
+                self._value = None
+                self.children = []
+                self._parseTree(self._tree)
+                children_updated = True
+        else:
+            if isinstance(setTo, bool):
                 if setTo:
                     if self._is_yesno_bool(self._value):
                         setTo = 'yes'
@@ -184,9 +195,8 @@ class ParsedValue(AccessesTree):
                         setTo = 'no'
                     else:
                         setTo = 'false'
-            self._value = sexpdata.Symbol(setTo)
-        else:
-            if isinstance(self._value, sexpdata.Symbol):
+                self._value = sexpdata.Symbol(setTo)
+            elif isinstance(self._value, sexpdata.Symbol):
                 self._value = sexpdata.Symbol(setTo)
             else:
                 self._value = setTo
@@ -197,8 +207,10 @@ class ParsedValue(AccessesTree):
                 c = c[self._base_coords[i]]
                 
             if isinstance(c, list) and len(c) > 1:
-                if isinstance(self._value, list):
-                    c[1:] = self._value 
+                if children_updated:
+                    c[1:] = self._tree[1:]
+                elif isinstance(self._value, list):
+                    c[1:] = self._value
                     #print(f"Setting values as list on {c}")
                 else:
                     c[1] = self._value


### PR DESCRIPTION
Sometimes we may want to add a new attribute to a node by assign a sexpdata tree to .value. But the fields are not updated according to the new value. For example _value and children is not updated which may causes problem if further operations depend on these fields. 

This enhancement is to enhance the ParsedValue.value setter to update the fields according to assignee. I have verified the new function by adding a hide = yes attribute to a property string. The test code is like.

>>> sch.symbol.C70.property.LCSC_Part__.effects.value = [[Symbol('font'), [Symbol('size'), 1.27, 1.27]], [Symbol('hide'), Symbol('yes')]]
OVERWRITING font
>>> sch.symbol.C70.property.LCSC_Part__.effects
<effects [font = [<size [1.27, 1.27]>], hide = True]>
>>> sch.symbol.C70.property.LCSC_Part__.effects._tree
[Symbol('effects'), [Symbol('font'), [Symbol('size'), 1.27, 1.27]], [Symbol('hide'), Symbol('yes')]]
>>> sch.symbol.C70.property.LCSC_Part__.effects._value
>>> sch.symbol.C70.property.LCSC_Part__.effects.font
font = [<size [1.27, 1.27]>]
>>> sch.symbol.C70.property.LCSC_Part__.effects.hide
hide = True